### PR TITLE
Shorten the control path length

### DIFF
--- a/{{cookiecutter.project_name}}/ansible.cfg
+++ b/{{cookiecutter.project_name}}/ansible.cfg
@@ -6,3 +6,6 @@ host_key_checking = True
 roles_path = ./shared-roles
 become = True
 ansible_managed = Ansible managed by {{ cookiecutter.project_name }} deploy
+
+[ssh_connection]
+control_path=%(directory)s/%%C


### PR DESCRIPTION
Ansible creates a unix domain socket and if the hostname is too long, the socket path name exceeds the maximum length.  The max is 108/104 characters on Linux/OSX.
http://serverfault.com/questions/641347/check-if-a-path-exceeds-maximum-for-unix-domain-socket

Most of the path length is fixed.  We can shorten the variable part with this change.  Below is an example with sensitive information anonymized.

```
/Users/john.ubantf/.ansible/cp/ansible-ssh-12.12.123.321-10155-john.ubantf.YMm1lNkdVHLEDHrP
/Users/john.ubantf/.ansible/cp/ansible-ssh-hh3-vic-ext-schair.cdfs.whizzbangs.com-22-john.ubantf.GZ2VTLbtLCkE2FmB
00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001111111111
00000000001111111111222222222233333333334444444444555555555566666666667777777777888888888899999999990000000000
01234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789
```

The above shows that the shortened version still allows for a long username or home directory path.

Ref:
http://blog.bilak.info/2015/10/07/too-long-for-unix-domain-socket/
https://github.com/ansible/ansible/issues/12144
https://en.wikibooks.org/wiki/OpenSSH/Cookbook/Multiplexing#Manually_Establishing_Multiplexed_Connections